### PR TITLE
Update references to VS2019 and netcore 3.1

### DIFF
--- a/paas-foundations/app-service-net-core-poc.md
+++ b/paas-foundations/app-service-net-core-poc.md
@@ -7,7 +7,7 @@ A .Net Core Multi-Tier PaaS Sample Application. During this POC you will learn a
 * To complete the Proof of Concept, you will need:
     * A Microsoft Azure subscription (with Owner or Contributor access)
 
-    * Install latest version of [Visual Studio 2017](https://www.visualstudio.com/downloads/) Enterprise with following Workloads:
+    * Install latest version of [Visual Studio 2019](https://www.visualstudio.com/downloads/) Enterprise with following Workloads:
       * .NET desktop development 
       * ASP.NET and web development 
       * Azure development  
@@ -111,7 +111,7 @@ Type ‘web app’ in the search box
 * Select the resource group you created
 * Type in the name of the web app (or API app) that you chose in the planning section
 * Set Publish to code
-* Set the Runtime stack to .Net Core 2.2
+* Set the Runtime stack to .Net Core 3.1
 * Set the operating system to Windows
 * Choose the Azure region that you decided on in the planning section as the location
 * Choose the app service plan you created


### PR DESCRIPTION
Changed mentions to VS2017 and netcore 2.2 by latest ones. The updated code is attached, I guess I'm not able to update it in the storage account.

[ContosoCore-netcore3.1.zip](https://github.com/Azure/fta-azurefoundations/files/4649915/ContosoCore-netcore3.1.zip)

@nomitapaul, @colincole @xstof, I hope this is useful after your review and you can approve the PR.